### PR TITLE
Py netgear plus refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
           zip netgear_plus.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: "softprops/action-gh-release@v2.2.0"
+        uses: "softprops/action-gh-release@v2.1.0"
         with:
           files: ${{ github.workspace }}/custom_components/netgear_plus/netgear_plus.zip

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/ckarrie/ha-netgear-plus/blob/main/README.md",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
-  "requirements": ["lxml>=4.6.1", "py-netgear-plus>0.3.0"],
+  "requirements": ["lxml>=4.6.1", "py-netgear-plus==0.3.1pre1"],
   "ssdp": [
     {
       "manufacturer": "NETGEAR",

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -6,12 +6,12 @@
   "documentation": "https://github.com/ckarrie/ha-netgear-plus/blob/main/README.md",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
-  "requirements": ["lxml>=4.6.1", "py-netgear-plus>=0.3.0"],
+  "requirements": ["lxml>=4.6.1", "py-netgear-plus>0.3.0"],
   "ssdp": [
     {
       "manufacturer": "NETGEAR",
       "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
     }
   ],
-  "version": "0.7.0"
+  "version": "0.7.1pre0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.9.0
 homeassistant==2024.12.5
 lxml>=4.6.1
-py-netgear-plus==0.3.0
+py-netgear-plus==0.3.1pre1
 pip>=21.3.1
 ruff==0.8.4


### PR DESCRIPTION
## Pre-release

Do not install unless you want (need) to test.
Bumps py-netgear-plus dependency to v0.3.1pre1
