### PR TITLE
Bump py-netgear-plus to v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Supported firmware languages: GR (German), EN (English)
 
 | Model     | Support status  |
 | --------- | --------------- |
+| JGS524Ev2 | In progress     |
 | GS108PEv3 | Not yet started |
 | GS105Ev2  | Not yet started |
 | GS110EMX  | Not yet started |

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -6,12 +6,12 @@
   "documentation": "https://github.com/ckarrie/ha-netgear-plus/blob/main/README.md",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
-  "requirements": ["lxml>=4.6.1", "py-netgear-plus==0.4.0"],
+  "requirements": ["lxml>=4.6.1", "py-netgear-plus==0.4.1"],
   "ssdp": [
     {
       "manufacturer": "NETGEAR",
       "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
     }
   ],
-  "version": "0.7.2"
+  "version": "0.7.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.9.0
 homeassistant==2024.12.5
 lxml>=4.6.1
-py-netgear-plus==0.4.0
+py-netgear-plus==0.4.1
 pip>=21.3.1
 ruff==0.9.1


### PR DESCRIPTION
Fixes:
* regression bug for GS108Ev3 (not parsing port status)
* fixes GS316EP(P) parsing for connection speed (ckarrie/ha-netgear-plus#72)