### PR TITLE
Bump py-netgear-plus to 0.4.3

### DIFF
--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -6,12 +6,12 @@
   "documentation": "https://github.com/ckarrie/ha-netgear-plus/blob/main/README.md",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
-  "requirements": ["lxml>=4.6.1", "py-netgear-plus==v0.4.3rc1"],
+  "requirements": ["lxml>=4.6.1", "py-netgear-plus==v0.4.3"],
   "ssdp": [
     {
       "manufacturer": "NETGEAR",
       "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
     }
   ],
-  "version": "0.7.5rc1"
+  "version": "0.7.5"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.9.0
 homeassistant>=2024.12.5
 lxml>=4.6.1
-py-netgear-plus==v0.4.3rc1
+py-netgear-plus==v0.4.3
 pip>=21.3.1
 ruff==0.9.4


### PR DESCRIPTION
## Changes in py-netgear-plus (0.4.2->0.4.3)


*  Gs316ep led switch by @foxey in foxey/py-netgear-plus#38
*    Bump pypa/gh-action-pypi-publish from 1.12.3 to 1.12.4 by @dependabot in foxey/py-netgear-plus#37
*    Bump ruff from 0.9.2 to 0.9.3 by @dependabot in foxey/py-netgear-plus#36
*    GS110EMX support by @foxey in foxey/py-netgear-plus#39
*    Fixes by @foxey in foxey/py-netgear-plus#41
*    Bump actions/setup-python from 5.3.0 to 5.4.0 by @dependabot in foxey/py-netgear-plus#42
*    Bump ruff from 0.9.3 to 0.9.4 by @dependabot in foxey/py-netgear-plus#43
*    Initial support for XS512EM by @foxey in foxey/py-netgear-plus#44
*    fixes GS108PEv3 support by @foxey in foxey/py-netgear-plus#45
